### PR TITLE
Return 401 in all cases of failure

### DIFF
--- a/basicauth.go
+++ b/basicauth.go
@@ -10,11 +10,8 @@ import (
 )
 
 var (
-	// ErrNoCreds is returned when no basic auth credentials are defined
-	ErrNoCreds = errors.New("no basic auth credentials defined")
-
-	// ErrAuthFail is returned when the client fails basic authentication
-	ErrAuthFail = errors.New("invalid basic auth username or password")
+	// ErrUnauthorized is returned when basic authentication failed
+	ErrUnauthorized = errors.New("Unauthorized")
 )
 
 // Authorizer is used to authenticate the basic auth username/password.
@@ -28,22 +25,22 @@ func Middleware(auth Authorizer) buffalo.MiddlewareFunc {
 			token := strings.SplitN(c.Request().Header.Get("Authorization"), " ", 2)
 			if len(token) != 2 {
 				c.Response().Header().Set("WWW-Authenticate", `Basic realm="Basic Authentication"`)
-				return c.Error(http.StatusUnauthorized, errors.New("Unauthorized"))
+				return c.Error(http.StatusUnauthorized, ErrUnauthorized)
 			}
 			b, err := base64.StdEncoding.DecodeString(token[1])
 			if err != nil {
-				return ErrAuthFail
+				return c.Error(http.StatusUnauthorized, ErrUnauthorized)
 			}
 			pair := strings.SplitN(string(b), ":", 2)
 			if len(pair) != 2 {
-				return ErrAuthFail
+				return c.Error(http.StatusUnauthorized, ErrUnauthorized)
 			}
 			success, err := auth(c, pair[0], pair[1])
 			if err != nil {
 				return errors.WithStack(err)
 			}
 			if !success {
-				return ErrAuthFail
+				return c.Error(http.StatusUnauthorized, ErrUnauthorized)
 			}
 			return next(c)
 		}

--- a/basicauth_test.go
+++ b/basicauth_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/httptest"
-	"github.com/gobuffalo/mw-basicauth"
+	"github.com/robsliwi/mw-basicauth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,8 +29,6 @@ func TestBasicAuth(t *testing.T) {
 
 	w := httptest.New(app())
 
-	authfail := "invalid basic auth"
-
 	// missing authorization
 	res := w.HTML("/").Get()
 	r.Equal(401, res.Code)
@@ -48,21 +46,27 @@ func TestBasicAuth(t *testing.T) {
 	req = w.HTML("/")
 	req.Headers["Authorization"] = "bad creds"
 	res = req.Get()
-	r.Equal(500, res.Code)
-	r.Contains(res.Body.String(), authfail)
-
-	creds := base64.StdEncoding.EncodeToString([]byte("badcredvalue"))
+	r.Equal(401, res.Code)
+	r.Contains(res.Body.String(), "Unauthorized")
 
 	// invalid cred values in authorization
+	creds := base64.StdEncoding.EncodeToString([]byte("badcredvalue"))
 	req = w.HTML("/")
 	req.Headers["Authorization"] = fmt.Sprintf("Basic %s", creds)
 	res = req.Get()
-	r.Equal(500, res.Code)
-	r.Contains(res.Body.String(), authfail)
+	r.Equal(401, res.Code)
+	r.Contains(res.Body.String(), "Unauthorized")
 
-	creds = base64.StdEncoding.EncodeToString([]byte("tester:pass123"))
+	// wrong cred values in authorization
+	creds = base64.StdEncoding.EncodeToString([]byte("foo:bar"))
+	req = w.HTML("/")
+	req.Headers["Authorization"] = fmt.Sprintf("Basic %s", creds)
+	res = req.Get()
+	r.Equal(401, res.Code)
+	r.Contains(res.Body.String(), "Unauthorized")
 
 	// valid cred values
+	creds = base64.StdEncoding.EncodeToString([]byte("tester:pass123"))
 	req = w.HTML("/")
 	req.Headers["Authorization"] = fmt.Sprintf("Basic %s", creds)
 	res = req.Get()


### PR DESCRIPTION
In some cases buffalo would return a 500 instead
of a 401 when the authorization fails.
This commit should fix this behavior, see
discussion in Slack:
https://gophers.slack.com/archives/C3MSAFD40/p1543923920092000